### PR TITLE
Disable SetBoosted when the game version is above 1.2.88

### DIFF
--- a/functions/pawn.lua
+++ b/functions/pawn.lua
@@ -782,19 +782,23 @@ function onPawnClassInitialized(BoardPawn, pawn)
 		self:SetAcidVanilla(acid)
 	end
 
-	BoardPawn.SetBoosted = function(self, boosted)
-		Assert.Equals("userdata", type(self), "Argument #0")
-		Assert.Equals("boolean", type(boosted), "Argument #1")
+	-- Use memEdit for SetBoosted prior to 1.2.88,
+	-- when vanilla SetBoosted was added.
+	if modApi:isVersionBelow(modApi:getGameVersion(), "1.2.88") then
+		BoardPawn.SetBoosted = function(self, boosted)
+			Assert.Equals("userdata", type(self), "Argument #0")
+			Assert.Equals("boolean", type(boosted), "Argument #1")
 
-		try(function()
-			memedit:require().pawn.setBoosted(self, boosted)
-		end)
-		:catch(function(err)
-			error(string.format(
-					"memedit.dll: %s",
-					tostring(err)
-			))
-		end)
+			try(function()
+				memedit:require().pawn.setBoosted(self, boosted)
+			end)
+			:catch(function(err)
+				error(string.format(
+						"memedit.dll: %s",
+						tostring(err)
+				))
+			end)
+		end
 	end
 
 	BoardPawn.SetClass = function(self, class)


### PR DESCRIPTION
Update to only create SetBoosted if game version is below 1.2.88 (when the vanilla SetBoosted became available).

See https://github.com/itb-community/ITB-ModLoader/issues/187