### PR TITLE
Override GetMutation and IsMutation

### DIFF
--- a/functions/pawn.lua
+++ b/functions/pawn.lua
@@ -237,6 +237,55 @@ function onPawnClassInitialized(BoardPawn, pawn)
 		return result
 	end
 
+	BoardPawn.GetMutationVanilla = BoardPawn.GetMutation
+	BoardPawn.GetMutation = function(self)
+		Assert.Equals("userdata", type(self), "Argument #0")
+
+		local memedit = memedit:get()
+
+		if memedit then
+			local result
+
+			try(function()
+				result = memedit:require().pawn.getMutation(self)
+			end)
+			:catch(function(err)
+				error(string.format(
+						"memedit.dll: %s",
+						tostring(err)
+				))
+			end)
+
+			return result
+		end
+
+		return self:GetMutationVanilla()
+	end
+
+	BoardPawn.IsMutationVanilla = BoardPawn.IsMutation
+	BoardPawn.IsMutation = function(self, predicate)
+		Assert.Equals("userdata", type(self), "Argument #0")
+		Assert.Equals("number", type(predicate), "Argument #1")
+
+		local memedit = memedit:get()
+
+		if memedit then
+			local mutation = self:GetMutation()
+			local isLeaderMutation = false
+				or predicate == LEADER_HEALTH
+				or predicate == LEADER_REGEN
+				or predicate == LEADER_EXPLODE
+
+			if mutation == LEADER_BOSS and isLeaderMutation then
+				predicate = LEADER_BOSS
+			end
+
+			return predicate == mutation
+		end
+
+		return self:IsMutationVanilla(predicate)
+	end
+	
 	BoardPawn.GetMaxBaseHealth = function(self)
 		Assert.Equals("userdata", type(self), "Argument #0")
 

--- a/functions/pawn.lua
+++ b/functions/pawn.lua
@@ -247,7 +247,7 @@ function onPawnClassInitialized(BoardPawn, pawn)
 			local result
 
 			try(function()
-				result = memedit:require().pawn.getMutation(self)
+				result = memedit.pawn.getMutation(self)
 			end)
 			:catch(function(err)
 				error(string.format(

--- a/tests/pawn.lua
+++ b/tests/pawn.lua
@@ -236,6 +236,26 @@ testsuite.test_Pawn_Leader = function()
 	return true
 end
 
+testsuite.test_Pawn_Mutation = function()
+	local memedit = memedit:get()
+
+	if memedit then
+		local mutation = LEADER_NONE
+		local pawn = PAWN_FACTORY:CreatePawn("Scorpion1")
+
+		Assert.Equals(mutation, pawn:GetMutation())
+
+		pawn:SetMutation(LEADER_ARMOR)
+		Assert.Equals(LEADER_ARMOR, pawn:GetMutation())
+	else
+		local pawn = PAWN_FACTORY:CreatePawn("Scorpion1")
+		Assert.ShouldError(pawn.GetMutation, {pawn}, "Function should fail without memedit")
+		Assert.ShouldError(pawn.SetMutation, {pawn, LEADER_ARMOR}, "Function should fail without memedit")
+	end
+
+	return true
+end
+
 testsuite.test_Pawn_Massive = function()
 	local memedit = memedit:get()
 

--- a/tests/pawn.lua
+++ b/tests/pawn.lua
@@ -237,21 +237,19 @@ testsuite.test_Pawn_Leader = function()
 end
 
 testsuite.test_Pawn_Mutation = function()
-	local memedit = memedit:get()
+	local mutation = Scorpion1.Leader
+	local pawn = PAWN_FACTORY:CreatePawn("Scorpion1")
 
-	if memedit then
-		local mutation = LEADER_NONE
-		local pawn = PAWN_FACTORY:CreatePawn("Scorpion1")
+	Assert.Equals(mutation, pawn:GetMutation())
+	Assert.True(pawn:IsMutation(mutation))
 
-		Assert.Equals(mutation, pawn:GetMutation())
+	pawn:SetMutation(LEADER_ARMOR)
+	Assert.Equals(LEADER_ARMOR, pawn:GetMutation())
+	Assert.True(pawn:IsMutation(LEADER_ARMOR))
 
-		pawn:SetMutation(LEADER_ARMOR)
-		Assert.Equals(LEADER_ARMOR, pawn:GetMutation())
-	else
-		local pawn = PAWN_FACTORY:CreatePawn("Scorpion1")
-		Assert.ShouldError(pawn.GetMutation, {pawn}, "Function should fail without memedit")
-		Assert.ShouldError(pawn.SetMutation, {pawn, LEADER_ARMOR}, "Function should fail without memedit")
-	end
+	pawn:SetMutation(LEADER_BOSS)
+	Assert.True(pawn:IsMutation(LEADER_BOSS))
+	Assert.True(pawn:IsMutation(LEADER_REGEN))
 
 	return true
 end


### PR DESCRIPTION
Replace #6 to remove the accidental address updates.

Overrides the modloader's `pawn:GetMutation` and `pawn:IsMutation` functions to use the memedit `pawn:GetMutation` function when memedit is available.